### PR TITLE
Implement subscriptions feature

### DIFF
--- a/app/components/cart/cart.tsx
+++ b/app/components/cart/cart.tsx
@@ -207,7 +207,11 @@ function CartLineItem({
 
   return (
     <li
-      className={clsx("flex gap-4", layout === "page" && "not-last:pb-6")}
+      className={clsx(
+        "flex gap-4",
+        layout === "page" && "not-last:pb-6",
+        className,
+      )}
       style={{
         // Hide the line item if the optimistic data action is remove
         // Do not remove the form from the DOM
@@ -248,12 +252,13 @@ function CartLineItem({
             {formattedVariant && (
               <div className="text-body-subtle text-sm">{formattedVariant}</div>
             )}
-            {line.sellingPlanAllocation?.sellingPlan?.name && (
-              <div className="mt-3 inline-flex items-center gap-1 rounded bg-[#EBE8E5] px-2.5 py-1 text-xs text-body-subtle">
-                <SubscriptionIcon className="h-3 w-3" />
-                <span>{line.sellingPlanAllocation.sellingPlan.name}</span>
-              </div>
-            )}
+            {layout === "drawer" &&
+              line.sellingPlanAllocation?.sellingPlan?.name && (
+                <div className="mt-3 inline-flex items-center gap-1 rounded bg-[#EBE8E5] px-2.5 py-1 text-xs text-body-subtle">
+                  <SubscriptionIcon className="h-3 w-3" />
+                  <span>{line.sellingPlanAllocation.sellingPlan.name}</span>
+                </div>
+              )}
           </div>
           {layout === "page" && (
             <ItemRemoveButton lineId={id} className="-mt-1" />

--- a/app/components/customer/account-subscriptions.tsx
+++ b/app/components/customer/account-subscriptions.tsx
@@ -1,0 +1,29 @@
+import { ArrowRight, Repeat } from "@phosphor-icons/react";
+import { Link } from "react-router";
+
+interface AccountSubscriptionsProps {
+  className?: string;
+}
+
+export function AccountSubscriptions({ className }: AccountSubscriptionsProps) {
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between border-b border-line pb-4 mb-4">
+        <h2 className="font-medium text-lg flex items-center gap-2">
+          <Repeat className="h-5 w-5" />
+          Subscriptions
+        </h2>
+        <Link
+          to="/account/subscriptions"
+          className="flex items-center gap-1 text-sm text-body-subtle hover:text-body transition-colors"
+        >
+          Manage subscriptions
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+      <p className="text-sm text-body-subtle">
+        View and manage your recurring subscription orders.
+      </p>
+    </div>
+  );
+}

--- a/app/components/product/add-to-cart-button.tsx
+++ b/app/components/product/add-to-cart-button.tsx
@@ -92,7 +92,7 @@ function usePageAnalytics({ hasUserConsent }: { hasUserConsent: boolean }) {
   }, [matches, hasUserConsent]);
 }
 
-function AddToCartAnalytics({
+export function AddToCartAnalytics({
   fetcher,
   children,
 }: {
@@ -127,10 +127,21 @@ function AddToCartAnalytics({
           cartId: fetcherData.cart.id,
         };
 
-        sendShopifyAnalytics({
-          eventName: AnalyticsEventName.ADD_TO_CART,
-          payload: addToCartPayload,
-        });
+        const hasSubscription =
+          Array.isArray(cartInputs.inputs.lines) &&
+          cartInputs.inputs.lines.some((line: any) => line.sellingPlanId);
+
+        if (hasSubscription) {
+          sendShopifyAnalytics({
+            eventName: "subscription_added_to_cart" as any,
+            payload: addToCartPayload,
+          });
+        } else {
+          sendShopifyAnalytics({
+            eventName: AnalyticsEventName.ADD_TO_CART,
+            payload: addToCartPayload,
+          });
+        }
       }
     }
   }, [fetcherData, formData, pageAnalytics]);

--- a/app/components/product/purchase-method-dropdown.tsx
+++ b/app/components/product/purchase-method-dropdown.tsx
@@ -1,0 +1,128 @@
+import { CaretDown } from "@phosphor-icons/react";
+import { useEffect, useRef, useState } from "react";
+import type { SellingPlanGroupFragment } from "storefront-api.generated";
+import { cn } from "~/utils/cn";
+import {
+  formatSellingPlanName,
+  getAvailableSellingPlans,
+} from "~/utils/selling-plan-utils";
+
+interface PurchaseMethodDropdownProps {
+  sellingPlanGroups: { nodes: SellingPlanGroupFragment[] };
+  selectedPlanId: string | null;
+  onPlanChange: (planId: string | null) => void;
+  disabled?: boolean;
+}
+
+export function PurchaseMethodDropdown({
+  sellingPlanGroups,
+  selectedPlanId,
+  onPlanChange,
+  disabled = false,
+}: PurchaseMethodDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const availablePlans = getAvailableSellingPlans(sellingPlanGroups);
+  const selectedPlan = availablePlans.find((p) => p.id === selectedPlanId);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }
+  }, [isOpen]);
+
+  const handleSelect = (planId: string | null) => {
+    onPlanChange(planId);
+    setIsOpen(false);
+  };
+
+  const displayText = selectedPlan
+    ? formatSellingPlanName(selectedPlan)
+    : "One time purchase";
+
+  return (
+    <div ref={dropdownRef} className="relative w-full">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        disabled={disabled}
+        className={cn(
+          "w-full h-11 flex items-center justify-between gap-4 px-3 text-sm border-2 border-(--color-line) rounded bg-white",
+          disabled && "opacity-50 cursor-not-allowed",
+        )}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <span className="truncate text-left text-sm">{displayText}</span>
+        <CaretDown
+          size={16}
+          className={cn("shrink-0 transition", isOpen && "rotate-180")}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-50 mt-1 w-full bg-white border border-(--color-line) rounded-[8px] shadow-lg max-h-60 overflow-auto">
+          <ul className="py-1">
+            {/* One-time purchase option */}
+            <li>
+              <button
+                type="button"
+                onClick={() => handleSelect(null)}
+                className={cn(
+                  "w-full text-left px-3 py-3.5 text-[14px] hover:bg-gray-100 transition",
+                  !selectedPlanId && "bg-gray-50 font-medium",
+                )}
+                role="option"
+                aria-selected={!selectedPlanId}
+              >
+                One time purchase
+              </button>
+            </li>
+
+            {/* Divider */}
+            {availablePlans.length > 0 && (
+              <li className="border-t border-(--color-line) my-1" />
+            )}
+
+            {/* Subscription options */}
+            {availablePlans.map((plan) => {
+              const isSelected = selectedPlanId === plan.id;
+
+              return (
+                <li key={plan.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(plan.id)}
+                    className={cn(
+                      "w-full text-left px-3 py-3.5 text-[14px] hover:bg-gray-100 transition",
+                      isSelected && "bg-gray-50 font-medium",
+                    )}
+                    role="option"
+                    aria-selected={isSelected}
+                  >
+                    <span className="truncate">
+                      {formatSellingPlanName(plan)}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/product/quick-shop.tsx
+++ b/app/components/product/quick-shop.tsx
@@ -29,6 +29,7 @@ export function QuickShop({
 
   const variants = product?.variants?.nodes || [];
   const firstImage = product?.media?.nodes?.[0];
+  const sellingPlanGroups = product?.sellingPlanGroups || { nodes: [] };
 
   const priceRange = product?.priceRange;
   const minPrice = priceRange?.minVariantPrice?.amount;
@@ -44,7 +45,7 @@ export function QuickShop({
 
   return (
     <div className="bg-background p-6">
-      <div className="mb-6 flex flex-col gap-6 md:flex-row">
+      <div className="mb-6 flex flex-col gap-12 md:flex-row">
         <div className="mt-4 md:mt-0 aspect-square w-full md:w-60 flex-shrink-0 overflow-hidden rounded bg-gray-100">
           {firstImage && (
             <ProductMedia
@@ -85,22 +86,42 @@ export function QuickShop({
       </div>
 
       <div className="space-y-6">
-        <div className="space-y-4">
+        <div className="space-y-6">
           {/* mobile header */}
-          <div className="border-b border-line-subtle pb-3 md:hidden">
-            <div className="text-sm font-bold uppercase">Products</div>
+          <div className="border-b border-line-subtle py-3 md:hidden">
+            <div className="text-sm font-semibold uppercase">Products</div>
           </div>
           {/* tablet/desktop header */}
-          <div className="hidden md:grid grid-cols-[3fr_1fr_1fr_1fr] gap-4 border-b border-line-subtle pb-3 lg:grid-cols-[3fr_1fr_1fr_1fr]">
-            <div className="text-sm font-bold uppercase">Variant</div>
-            <div className="text-center text-sm font-bold uppercase">
-              Quantity
+          {sellingPlanGroups?.nodes?.length > 0 ? (
+            <div className="hidden md:grid grid-cols-[1fr_280px_270px_160px_153px] gap-6 border-b border-line-subtle py-3">
+              <div className="text-sm font-semibold uppercase">Variant</div>
+              <div className="text-sm font-semibold uppercase text-center">
+                Purchase Method
+              </div>
+              <div className="text-sm font-semibold uppercase text-center">
+                Quantity
+              </div>
+              <div className="text-sm font-semibold uppercase text-center">
+                Price
+              </div>
+              <div className="text-sm font-semibold uppercase text-right">
+                Variant Price
+              </div>
             </div>
-            <div className="text-center text-sm font-bold uppercase">Price</div>
-            <div className="text-right text-sm font-bold uppercase">
-              Variant Price
+          ) : (
+            <div className="hidden md:grid grid-cols-[1fr_270px_160px_153px] gap-6 border-b border-line-subtle py-3">
+              <div className="text-sm font-semibold uppercase">Variant</div>
+              <div className="text-sm font-semibold uppercase text-center">
+                Quantity
+              </div>
+              <div className="text-sm font-semibold uppercase text-center">
+                Price
+              </div>
+              <div className="text-sm font-semibold uppercase text-right">
+                Variant Price
+              </div>
             </div>
-          </div>
+          )}
           <Await resolve={rootData?.cart}>
             {(resolvedCart) => (
               <>
@@ -110,6 +131,7 @@ export function QuickShop({
                       key={variant.id}
                       variant={variant}
                       cart={resolvedCart}
+                      sellingPlanGroups={sellingPlanGroups}
                     />
                   ))}
                 </div>
@@ -199,17 +221,22 @@ export function QuickShopTrigger({
           }
           aria-describedby={undefined}
         >
+          <Dialog.Close asChild>
+            <Button
+              className="absolute top-3 right-3 rounded-full p-2"
+              variant="secondary"
+            >
+              <XIcon size={18} />
+            </Button>
+          </Dialog.Close>
           <div
             style={{ maxHeight: "90vh" }}
             className={clsx(
               "relative mx-auto h-auto w-full overflow-y-auto",
-              "animate-slide-up bg-white shadow-sm",
+              "animate-slide-up bg-white shadow-sm rounded-[4px]",
               "max-w-7xl",
             )}
           >
-            <Dialog.Close asChild>
-              <XIcon className="absolute top-3 right-3 z-10 h-5 w-5 cursor-pointer" />
-            </Dialog.Close>
             <VisuallyHidden.Root asChild>
               <Dialog.Title>Quick shop modal</Dialog.Title>
             </VisuallyHidden.Root>

--- a/app/components/product/selling-plan-selector.tsx
+++ b/app/components/product/selling-plan-selector.tsx
@@ -1,0 +1,150 @@
+import { Money } from "@shopify/hydrogen";
+import clsx from "clsx";
+import { useLocation, useNavigate } from "react-router";
+import type { SellingPlanGroupFragment } from "storefront-api.generated";
+
+interface SellingPlanSelectorProps {
+  sellingPlanGroups: {
+    nodes: SellingPlanGroupFragment[];
+  };
+  selectedSellingPlanId: string | null;
+}
+
+export function SellingPlanSelector({
+  sellingPlanGroups,
+  selectedSellingPlanId,
+}: SellingPlanSelectorProps) {
+  const { search, pathname } = useLocation();
+  const navigate = useNavigate();
+
+  const availableGroups =
+    sellingPlanGroups?.nodes?.filter(
+      (group) => group.sellingPlans.nodes.length > 0,
+    ) || [];
+
+  if (!availableGroups.length) {
+    return null;
+  }
+
+  const handleSellingPlanChange = (sellingPlanId: string | null) => {
+    const params = new URLSearchParams(search);
+    if (sellingPlanId) {
+      params.set("selling_plan", sellingPlanId);
+    } else {
+      params.delete("selling_plan");
+    }
+    navigate(`${pathname}?${params.toString()}`, { replace: true });
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* One-time purchase option */}
+      <label
+        className={clsx(
+          "flex items-center gap-3 cursor-pointer p-4 border rounded-sm transition-all relative",
+          selectedSellingPlanId
+            ? "border-line hover:border-body"
+            : "border-black bg-body/5 shadow-[0_0_0_1px_black]",
+        )}
+      >
+        <div className="flex items-center h-5">
+          <input
+            type="radio"
+            name="selling_plan"
+            checked={!selectedSellingPlanId}
+            onChange={() => handleSellingPlanChange(null)}
+            className="h-4 w-4 border-line text-black focus:ring-black accent-black cursor-pointer"
+          />
+        </div>
+        <div className="flex-1">
+          <span className="text-sm font-medium d-block text-body">
+            One-time purchase
+          </span>
+        </div>
+      </label>
+
+      {/* Subscription options */}
+      {availableGroups.map((group) => (
+        <div key={group.name} className="space-y-3">
+          <p className="text-xs uppercase tracking-wider font-bold text-body-subtle pt-2">
+            {group.name}
+          </p>
+          <div className="space-y-3">
+            {group.sellingPlans.nodes.map((plan) => {
+              const priceAdjustment = plan.priceAdjustments?.[0];
+              const adjustmentValue = priceAdjustment?.adjustmentValue;
+
+              let discountText = "";
+              if (adjustmentValue) {
+                if ("adjustmentPercentage" in adjustmentValue) {
+                  discountText = `Save ${adjustmentValue.adjustmentPercentage}%`;
+                } else if (
+                  "adjustmentAmount" in adjustmentValue &&
+                  adjustmentValue.adjustmentAmount
+                ) {
+                  discountText = "Save ";
+                }
+              }
+
+              const isSelected = selectedSellingPlanId === plan.id;
+
+              return (
+                <label
+                  key={plan.id}
+                  className={clsx(
+                    "flex items-center gap-3 cursor-pointer p-4 border rounded-sm transition-all relative",
+                    isSelected
+                      ? "border-black bg-body/5 shadow-[0_0_0_1px_black]"
+                      : "border-line hover:border-body",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="selling_plan"
+                    value={plan.id}
+                    checked={isSelected}
+                    onChange={() => handleSellingPlanChange(plan.id)}
+                    className="h-4 w-4 border-line text-black focus:ring-black accent-black cursor-pointer shrink-0"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                      <span
+                        className={clsx(
+                          "text-sm font-medium",
+                          isSelected ? "text-body" : "text-body-subtle",
+                        )}
+                      >
+                        {plan.name}
+                      </span>
+
+                      {discountText && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-green-100 text-green-800 whitespace-nowrap">
+                          {discountText}
+                          {adjustmentValue &&
+                            "adjustmentAmount" in adjustmentValue &&
+                            adjustmentValue.adjustmentAmount && (
+                              <span className="ml-1">
+                                <Money
+                                  data={adjustmentValue.adjustmentAmount}
+                                />
+                              </span>
+                            )}
+                        </span>
+                      )}
+                    </div>
+
+                    {plan.description && (
+                      <p className="text-xs text-body-subtle mt-1 leading-relaxed">
+                        {plan.description}
+                      </p>
+                    )}
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/root/custom-analytics.tsx
+++ b/app/components/root/custom-analytics.tsx
@@ -63,6 +63,15 @@ export function CustomAnalytics() {
     subscribe(AnalyticsEvent.PRODUCT_ADD_TO_CART, (data) => {
       console.log("CustomAnalytics - Product added to cart:", data);
     });
+    subscribe("subscription_added_to_cart" as any, (data: any) => {
+      console.log("CustomAnalytics - Subscription added to cart:", data);
+      dataToSentToGTM = {
+        event: "subscription_added_to_cart",
+        cart_id: data.cartId,
+        ...data,
+      };
+      window.dataLayer?.push(dataToSentToGTM);
+    });
     subscribe(AnalyticsEvent.PRODUCT_REMOVED_FROM_CART, (data) => {
       console.log("CustomAnalytics - Product removed from cart:", data);
     });

--- a/app/graphql/customer-account/CustomerSubscriptionsMutations.account.ts
+++ b/app/graphql/customer-account/CustomerSubscriptionsMutations.account.ts
@@ -1,0 +1,15 @@
+// NOTE: https://shopify.dev/docs/api/customer/latest/mutations/subscriptionContractCancel
+
+export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
+  mutation subscriptionContractCancel($subscriptionContractId: ID!) {
+    subscriptionContractCancel(subscriptionContractId: $subscriptionContractId) {
+      contract {
+        id
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+` as const;

--- a/app/graphql/customer-account/CustomerSubscriptionsQuery.account.ts
+++ b/app/graphql/customer-account/CustomerSubscriptionsQuery.account.ts
@@ -1,0 +1,66 @@
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+const SUBSCRIPTION_CONTRACT_FRAGMENT = `#graphql
+  fragment SubscriptionContract on SubscriptionContract {
+    id
+    status
+    createdAt
+    nextBillingDate
+    billingPolicy {
+      ...SubscriptionBillingPolicy
+    }
+    discounts(first: 20) {
+      nodes {
+        ...SubscriptionDiscountFragment
+      }
+    }
+  }
+  fragment SubscriptionBillingPolicy on SubscriptionBillingPolicy {
+    interval
+    intervalCount {
+      count
+      precision
+    }
+  }
+  fragment SubscriptionDiscountFragment on SubscriptionDiscount {
+    id
+    title
+    recurringCycleLimit
+    value {
+      __typename
+      ... on SubscriptionDiscountFixedAmountValue {
+        amount {
+          amount
+        }
+      }
+      ... on SubscriptionDiscountPercentageValue {
+        percentage
+      }
+    }
+  }
+` as const;
+
+export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
+  query SubscriptionsContractsQuery {
+    customer {
+      subscriptionContracts(first: 100) {
+        nodes {
+          ...SubscriptionContract
+          lines(first: 100) {
+            nodes {
+              name
+              id
+              image {
+                url
+                altText
+                width
+                height
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${SUBSCRIPTION_CONTRACT_FRAGMENT}
+` as const;

--- a/app/graphql/fragments.ts
+++ b/app/graphql/fragments.ts
@@ -189,3 +189,56 @@ export const MEDIA_FRAGMENT = `#graphql
     }
   }
 ` as const;
+
+export const SELLING_PLAN_FRAGMENT = `#graphql
+  fragment SellingPlanMoney on MoneyV2 {
+    amount
+    currencyCode
+  }
+  fragment SellingPlan on SellingPlan {
+    id
+    name
+    description
+    recurringDeliveries
+    options {
+      name
+      value
+    }
+    priceAdjustments {
+      adjustmentValue {
+        ... on SellingPlanFixedAmountPriceAdjustment {
+          __typename
+          adjustmentAmount {
+            ...SellingPlanMoney
+          }
+        }
+        ... on SellingPlanFixedPriceAdjustment {
+          __typename
+          price {
+            ...SellingPlanMoney
+          }
+        }
+        ... on SellingPlanPercentagePriceAdjustment {
+          __typename
+          adjustmentPercentage
+        }
+      }
+    }
+  }
+` as const;
+
+export const SELLING_PLAN_GROUP_FRAGMENT = `#graphql
+  fragment SellingPlanGroup on SellingPlanGroup {
+    name
+    options {
+      name
+      values
+    }
+    sellingPlans(first: 10) {
+      nodes {
+        ...SellingPlan
+      }
+    }
+  }
+  ${SELLING_PLAN_FRAGMENT}
+` as const;

--- a/app/graphql/queries.ts
+++ b/app/graphql/queries.ts
@@ -1,4 +1,8 @@
-import { MEDIA_FRAGMENT, PRODUCT_OPTION_FRAGMENT } from "~/graphql/fragments";
+import {
+  MEDIA_FRAGMENT,
+  PRODUCT_OPTION_FRAGMENT,
+  SELLING_PLAN_GROUP_FRAGMENT,
+} from "~/graphql/fragments";
 
 export const PRODUCT_QUERY = `#graphql
   query product(
@@ -85,6 +89,11 @@ export const PRODUCT_QUERY = `#graphql
           ...Media
         }
       }
+      sellingPlanGroups(first: 5) {
+        nodes {
+          ...SellingPlanGroup
+        }
+      }
       seo {
         description
         title
@@ -107,4 +116,5 @@ export const PRODUCT_QUERY = `#graphql
   }
   ${MEDIA_FRAGMENT}
   ${PRODUCT_OPTION_FRAGMENT}
+  ${SELLING_PLAN_GROUP_FRAGMENT}
 ` as const;

--- a/app/routes/($locale).account.subscriptions.tsx
+++ b/app/routes/($locale).account.subscriptions.tsx
@@ -1,0 +1,290 @@
+import { ArrowLeft, CircleNotchIcon, TagIcon, X } from "@phosphor-icons/react";
+import { Image } from "@shopify/hydrogen";
+import {
+  type ActionFunctionArgs,
+  data,
+  type LoaderFunctionArgs,
+} from "@shopify/remix-oxygen";
+import type { SubscriptionsContractsQueryQuery } from "customer-account-api.generated";
+import {
+  Form,
+  Link,
+  useActionData,
+  useLoaderData,
+  useNavigation,
+} from "react-router";
+import { Button } from "~/components/button";
+import { Section } from "~/components/section";
+import { SUBSCRIPTION_CANCEL_MUTATION } from "~/graphql/customer-account/CustomerSubscriptionsMutations.account";
+import { SUBSCRIPTIONS_CONTRACTS_QUERY } from "~/graphql/customer-account/CustomerSubscriptionsQuery.account";
+import { routeHeaders } from "~/utils/cache";
+
+export const headers = routeHeaders;
+
+type SubscriptionContract =
+  SubscriptionsContractsQueryQuery["customer"]["subscriptionContracts"]["nodes"][number];
+
+interface LoaderData {
+  subscriptions: SubscriptionContract[];
+}
+
+export async function loader({ context }: LoaderFunctionArgs) {
+  const { data: result } = await context.customerAccount.query(
+    SUBSCRIPTIONS_CONTRACTS_QUERY,
+  );
+
+  const subscriptions = result?.customer?.subscriptionContracts?.nodes || [];
+
+  return { subscriptions };
+}
+
+export async function action({ request, context }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const subscriptionContractId = formData.get(
+    "subscriptionContractId",
+  ) as string;
+
+  if (!subscriptionContractId) {
+    return data({ error: "Missing subscription ID" }, { status: 400 });
+  }
+
+  const { data: result, errors } = await context.customerAccount.mutate(
+    SUBSCRIPTION_CANCEL_MUTATION,
+    {
+      variables: { subscriptionContractId },
+    },
+  );
+
+  if (
+    errors?.length ||
+    result?.subscriptionContractCancel?.userErrors?.length
+  ) {
+    const errorMessage =
+      errors?.[0]?.message ||
+      result?.subscriptionContractCancel?.userErrors?.[0]?.message ||
+      "Failed to cancel subscription";
+    return data({ error: errorMessage }, { status: 400 });
+  }
+
+  return data({ success: true });
+}
+
+function getIntervalLabel(interval: string, count: number): string {
+  const intervalLabels: Record<string, string> = {
+    DAY: count === 1 ? "day" : "days",
+    WEEK: count === 1 ? "week" : "weeks",
+    MONTH: count === 1 ? "month" : "months",
+    YEAR: count === 1 ? "year" : "years",
+  };
+  return `${count} ${intervalLabels[interval] || interval.toLowerCase()}`;
+}
+
+function getStatusBadgeClass(status: string): string {
+  switch (status) {
+    case "ACTIVE":
+      return "bg-green-100 text-green-800";
+    case "PAUSED":
+      return "bg-yellow-100 text-yellow-800";
+    case "CANCELLED":
+      return "bg-red-100 text-red-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+}
+
+export default function AccountSubscriptions() {
+  const { subscriptions } = useLoaderData<LoaderData>();
+  const actionData = useActionData<{ error?: string; success?: boolean }>();
+  const navigation = useNavigation();
+
+  return (
+    <Section
+      width="fixed"
+      verticalPadding="medium"
+      containerClassName="space-y-8"
+    >
+      <div className="flex items-center gap-4">
+        <Link
+          to="/account"
+          className="flex items-center gap-2 text-body-subtle hover:text-body transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+          <span>Back to Account</span>
+        </Link>
+      </div>
+
+      <div className="space-y-2">
+        <h1 className="h3 font-medium">My Subscriptions</h1>
+        <p className="text-body-subtle">
+          Manage your active subscriptions and recurring orders.
+        </p>
+      </div>
+
+      {actionData?.error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-sm">
+          {actionData.error}
+        </div>
+      )}
+
+      {actionData?.success && (
+        <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-sm">
+          Subscription cancelled successfully.
+        </div>
+      )}
+
+      {subscriptions.length === 0 ? (
+        <div className="text-center py-24 space-y-6 border border-dashed border-line rounded-lg bg-gray-50">
+          <div className="mx-auto w-16 h-16 bg-white rounded-full flex items-center justify-center border border-line-subtle shadow-sm">
+            <CircleNotchIcon className="w-8 h-8 text-body-subtle" />
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-lg font-medium">No active subscriptions</h3>
+            <p className="text-body-subtle max-w-md mx-auto">
+              You don't have any active subscriptions yet. Subscribe to your favorite products to get regular deliveries and savings.
+            </p>
+          </div>
+          <Link to="/products">
+            <Button>Start Shopping</Button>
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {subscriptions.map((subscription) => (
+            <div
+              key={subscription.id}
+              className="flex flex-col border border-line rounded-lg overflow-hidden bg-background shadow-sm hover:shadow-md transition-shadow"
+            >
+              {/* Card Header */}
+              <div className="p-5 border-b border-line-subtle bg-gray-50/50 flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <div className="text-xs text-body-subtle font-medium uppercase tracking-wider">Status</div>
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium ${getStatusBadgeClass(
+                      subscription.status
+                    )}`}
+                  >
+                    {subscription.status}
+                  </span>
+                </div>
+                <div className="text-right space-y-1">
+                  <div className="text-xs text-body-subtle font-medium uppercase tracking-wider">Frequency</div>
+                  <div className="text-sm font-medium">
+                    Every {getIntervalLabel(
+                      subscription.billingPolicy.interval,
+                      subscription.billingPolicy.intervalCount.count
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Card Body */}
+              <div className="p-5 flex-1 space-y-6">
+                {/* Products */}
+                <div className="space-y-3">
+                  <h4 className="text-xs text-body-subtle font-medium uppercase tracking-wider">Product</h4>
+                  <ul className="space-y-3">
+                    {subscription.lines.nodes.map((line) => (
+                      <li key={line.id} className="flex items-start gap-3">
+                        {line.image ? (
+                          <div className="relative border border-line-subtle rounded shrink-0 overflow-hidden w-12 h-12">
+                            <Image
+                              data={line.image}
+                              className="w-full h-full object-cover"
+                              sizes="48px"
+                            />
+                          </div>
+                        ) : (
+                          <div className="w-12 h-12 bg-gray-100 rounded border border-line-subtle shrink-0"></div>
+                        )}
+                        <span className="text-sm font-medium line-clamp-2 leading-snug">
+                          {line.name}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                {/* Details */}
+                <div className="pt-2 space-y-3">
+                  {subscription.nextBillingDate && (
+                    <div className="flex justify-between items-baseline text-sm">
+                      <span className="text-body-subtle">Next Billing</span>
+                      <span className="font-semibold">
+                        {new Date(subscription.nextBillingDate).toLocaleDateString(undefined, {
+                          year: 'numeric',
+                          month: 'short',
+                          day: 'numeric'
+                        })}
+                      </span>
+                    </div>
+                  )}
+                  <div className="flex justify-between items-baseline text-sm">
+                    <span className="text-body-subtle">Started</span>
+                    <span>
+                      {new Date(subscription.createdAt).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric'
+                      })}
+                    </span>
+                  </div>
+                </div>
+
+                {subscription.discounts.nodes.length > 0 && (
+                  <div className="pt-4 border-t border-line-subtle">
+                    <div className="flex flex-wrap gap-2">
+                      {subscription.discounts.nodes.map((discount) => (
+                        <span key={discount.id} className="inline-flex items-center text-xs font-medium text-green-700 bg-green-50 px-2 py-1 rounded">
+                          <TagIcon className="w-3 h-3 mr-1" />
+                          {discount.title}
+                          {discount.value.__typename ===
+                            "SubscriptionDiscountPercentageValue" &&
+                            discount.value.percentage &&
+                            ` (-${discount.value.percentage}%)`}
+                          {discount.value.__typename ===
+                            "SubscriptionDiscountFixedAmountValue" &&
+                            discount.value.amount &&
+                            ` (-$${discount.value.amount.amount})`}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Card Footer */}
+              {subscription.status === "ACTIVE" && (
+                <div className="p-5 border-t border-line-subtle bg-gray-50/30">
+                  <Form method="post">
+                    <input
+                      type="hidden"
+                      name="subscriptionContractId"
+                      value={subscription.id}
+                    />
+                    <Button
+                      type="submit"
+                      variant="outline"
+                      className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300 transition-colors"
+                      disabled={navigation.state === "submitting"}
+                    >
+                      {navigation.state === "submitting" ? (
+                        <CircleNotchIcon className="h-4 w-4 mr-3 animate-spin" />
+                      ) : (
+                        <X className="h-4 w-4 mr-3" />
+                      )}
+                      {navigation.state === "submitting"
+                        ? "Cancelling..."
+                        : "Cancel Subscription"}
+                    </Button>
+                  </Form>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </Section>
+  );
+}
+
+

--- a/app/routes/($locale).account.tsx
+++ b/app/routes/($locale).account.tsx
@@ -21,6 +21,7 @@ import {
 import { AccountDetails } from "~/components/customer/account-details";
 import { AccountAddressBook } from "~/components/customer/address-book";
 import { AccountOrderHistory } from "~/components/customer/orders";
+import { AccountSubscriptions } from "~/components/customer/account-subscriptions";
 import { OutletModal } from "~/components/customer/outlet-modal";
 import { ProductCard } from "~/components/product/product-card";
 import { Section } from "~/components/section";
@@ -119,6 +120,7 @@ function Account({ customer, heading, featuredData }: AccountType) {
         </Form>
       </div>
       {orders ? <AccountOrderHistory orders={orders} /> : null}
+      <AccountSubscriptions />
       <AccountDetails customer={customer} />
       <AccountAddressBook addresses={addresses} customer={customer} />
       {!orders.length && (

--- a/app/sections/main-product/product-atc-buttons.tsx
+++ b/app/sections/main-product/product-atc-buttons.tsx
@@ -4,8 +4,9 @@ import {
   useOptimisticVariant,
 } from "@shopify/hydrogen";
 import { createSchema, type HydrogenComponentProps } from "@weaverse/hydrogen";
-import { useLoaderData } from "react-router";
-import { AddToCartButton } from "~/components/product/add-to-cart-button";
+import { useLoaderData, useSearchParams } from "react-router";
+// import { AddToCartButton } from "~/components/product/add-to-cart-button";
+import { SellingPlanSelector } from "~/components/product/selling-plan-selector";
 import type { loader as productRouteLoader } from "~/routes/($locale).products.$productHandle";
 import { isCombinedListing } from "~/utils/combined-listings";
 import { useProductQtyStore } from "./product-quantity-selector";
@@ -29,6 +30,8 @@ export default function ProductATCButtons(props: ProductATCButtonsProps) {
   } = props;
   const { product, storeDomain } = useLoaderData<typeof productRouteLoader>();
   const { quantity } = useProductQtyStore();
+  const [searchParams] = useSearchParams();
+  const sellingPlanId = searchParams.get("selling_plan");
 
   const selectedVariant = useOptimisticVariant(
     product?.selectedOrFirstAvailableVariant,
@@ -51,6 +54,13 @@ export default function ProductATCButtons(props: ProductATCButtonsProps) {
 
   return (
     <div ref={ref} {...rest} className="space-y-2 empty:hidden">
+      {!!product.sellingPlanGroups?.nodes?.length && (
+        <SellingPlanSelector
+          sellingPlanGroups={product.sellingPlanGroups}
+          selectedSellingPlanId={sellingPlanId}
+        />
+      )}
+      {/* TODO: Uncomment when not using Variant List
       <AddToCartButton
         disabled={!selectedVariant?.availableForSale}
         lines={[
@@ -58,6 +68,7 @@ export default function ProductATCButtons(props: ProductATCButtonsProps) {
             merchandiseId: selectedVariant?.id,
             quantity,
             selectedVariant,
+            sellingPlanId: sellingPlanId || undefined,
           },
         ]}
         data-test="add-to-cart"
@@ -65,6 +76,7 @@ export default function ProductATCButtons(props: ProductATCButtonsProps) {
       >
         {atcButtonText}
       </AddToCartButton>
+      */}
       {showShopPayButton && selectedVariant?.availableForSale && (
         <ShopPayButton
           width="100%"
@@ -119,7 +131,7 @@ export const schema = createSchema({
           type: "switch",
           label: "Show Shop Pay button",
           name: "showShopPayButton",
-          defaultValue: true,
+          defaultValue: false,
         },
       ],
     },

--- a/app/sections/main-product/product-prices.tsx
+++ b/app/sections/main-product/product-prices.tsx
@@ -1,9 +1,10 @@
 import {
   getAdjacentAndFirstAvailableVariants,
+  Money,
   useOptimisticVariant,
 } from "@shopify/hydrogen";
 import { createSchema, type HydrogenComponentProps } from "@weaverse/hydrogen";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useSearchParams } from "react-router";
 import { VariantPrices } from "~/components/product/variant-prices";
 import type { loader as productRouteLoader } from "~/routes/($locale).products.$productHandle";
 import { isCombinedListing } from "~/utils/combined-listings";
@@ -13,9 +14,69 @@ interface ProductPricesProps extends HydrogenComponentProps {
   showCompareAtPrice: boolean;
 }
 
+function SellingPlanPrice({
+  price,
+  sellingPlan,
+}: {
+  price: { amount: string; currencyCode: string };
+  sellingPlan: {
+    priceAdjustments: Array<{
+      adjustmentValue: {
+        adjustmentPercentage?: number;
+        adjustmentAmount?: { amount: string; currencyCode: string };
+        price?: { amount: string; currencyCode: string };
+      };
+    }>;
+  };
+}) {
+  const priceAdjustment = sellingPlan?.priceAdjustments?.[0];
+  const adjustmentValue = priceAdjustment?.adjustmentValue;
+
+  if (!adjustmentValue) {
+    return <Money withoutTrailingZeros data={price as any} />;
+  }
+
+  // Fixed price
+  if ("price" in adjustmentValue && adjustmentValue.price) {
+    return <Money withoutTrailingZeros data={adjustmentValue.price as any} />;
+  }
+
+  // Fixed amount off
+  if (
+    "adjustmentAmount" in adjustmentValue &&
+    adjustmentValue.adjustmentAmount
+  ) {
+    const adjustedPrice = {
+      amount: String(
+        Number(price.amount) - Number(adjustmentValue.adjustmentAmount.amount),
+      ),
+      currencyCode: price.currencyCode,
+    };
+    return <Money withoutTrailingZeros data={adjustedPrice as any} />;
+  }
+
+  // Percentage off
+  if (
+    "adjustmentPercentage" in adjustmentValue &&
+    adjustmentValue.adjustmentPercentage
+  ) {
+    const adjustedPrice = {
+      amount: String(
+        Number(price.amount) * (1 - adjustmentValue.adjustmentPercentage / 100),
+      ),
+      currencyCode: price.currencyCode,
+    };
+    return <Money withoutTrailingZeros data={adjustedPrice as any} />;
+  }
+
+  return <Money withoutTrailingZeros data={price as any} />;
+}
+
 export default function ProductPrices(props: ProductPricesProps) {
   const { ref, showCompareAtPrice, ...rest } = props;
   const { product } = useLoaderData<typeof productRouteLoader>();
+  const [searchParams] = useSearchParams();
+  const sellingPlanId = searchParams.get("selling_plan");
 
   const selectedVariant = useOptimisticVariant(
     product?.selectedOrFirstAvailableVariant,
@@ -27,6 +88,16 @@ export default function ProductPrices(props: ProductPricesProps) {
   if (!product) {
     return null;
   }
+
+  // Find the selected selling plan
+  const selectedSellingPlan = sellingPlanId
+    ? product.sellingPlanGroups?.nodes
+        ?.flatMap(
+          (group: { sellingPlans: { nodes: Array<{ id: string }> } }) =>
+            group.sellingPlans.nodes,
+        )
+        .find((plan: { id: string }) => plan.id === sellingPlanId)
+    : null;
 
   return (
     <div ref={ref} {...rest}>
@@ -45,6 +116,16 @@ export default function ProductPrices(props: ProductPricesProps) {
               variant={{ price: product.priceRange.maxVariantPrice }}
               showCompareAtPrice={false}
             />
+          </span>
+        </div>
+      ) : selectedSellingPlan && selectedVariant?.price ? (
+        <div className="flex items-center gap-2 text-2xl/none text-body-subtle">
+          <SellingPlanPrice
+            price={selectedVariant.price}
+            sellingPlan={selectedSellingPlan as any}
+          />
+          <span className="text-sm line-through text-body-subtle/60">
+            <Money withoutTrailingZeros data={selectedVariant.price} />
           </span>
         </div>
       ) : (

--- a/app/sections/main-product/product-subscription-selector.tsx
+++ b/app/sections/main-product/product-subscription-selector.tsx
@@ -1,0 +1,50 @@
+import { createSchema, type HydrogenComponentProps } from "@weaverse/hydrogen";
+import { useLoaderData, useSearchParams } from "react-router";
+import { SellingPlanSelector } from "~/components/product/selling-plan-selector";
+import type { loader as productRouteLoader } from "~/routes/($locale).products.$productHandle";
+import { isCombinedListing } from "~/utils/combined-listings";
+
+interface ProductSubscriptionSelectorProps extends HydrogenComponentProps {
+  ref: React.Ref<HTMLDivElement>;
+}
+
+export default function ProductSubscriptionSelector(
+  props: ProductSubscriptionSelectorProps,
+) {
+  const { ref, ...rest } = props;
+  const { product } = useLoaderData<typeof productRouteLoader>();
+  const [searchParams] = useSearchParams();
+
+  const combinedListing = isCombinedListing(product);
+
+  if (!product || combinedListing) {
+    return null;
+  }
+
+  const sellingPlanGroups = product.sellingPlanGroups;
+  const selectedSellingPlanId = searchParams.get("selling_plan");
+
+  // Only show if product has selling plans
+  if (!sellingPlanGroups?.nodes?.length) {
+    return null;
+  }
+
+  return (
+    <div ref={ref} {...rest}>
+      <SellingPlanSelector
+        sellingPlanGroups={sellingPlanGroups}
+        selectedSellingPlanId={selectedSellingPlanId}
+      />
+    </div>
+  );
+}
+
+export const schema = createSchema({
+  type: "mp--subscription-selector",
+  title: "Subscription selector",
+  limit: 1,
+  enabledOn: {
+    pages: ["PRODUCT"],
+  },
+  settings: [],
+});

--- a/app/sections/variant-list/subtotal.tsx
+++ b/app/sections/variant-list/subtotal.tsx
@@ -37,28 +37,90 @@ export function Subtotal({ cart: originalCart, variants }: SubtotalProps) {
     }, 0);
   }
   return (
-    <div className="border-t border-line-subtle pt-6">
-      <div className="grid grid-cols-[3fr_1fr_1fr_1fr] gap-4 items-center">
-        <div className="flex items-center gap-4">
-          <Button variant="outline" onClick={() => toggleCartDrawer(true)}>
-            View Cart
-          </Button>
-          {<RemoveAllFromCartButton lineIds={existingLineIds} />}
-        </div>
-        <div className="text-center">Total: {totalItems} items</div>
-        <div className="space-y-1 col-span-2">
-          <div className="text-right">
-            <div className="text-sm">Subtotal:</div>
-            <div className="font-semibold">${subtotal.toFixed(2)}</div>
+    <>
+      {/* mobile layout */}
+      <div className="border-t border-line-subtle pt-6 md:hidden">
+        <div className="space-y-3">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="outline"
+              className="text-sm"
+              onClick={() => toggleCartDrawer(true)}
+            >
+              View Cart
+            </Button>
+            {<RemoveAllFromCartButton lineIds={existingLineIds} />}
           </div>
-          <div className="text-right">
-            <div className="text-sm text-body-subtle">
-              Taxes, discounts and shipping calculated at checkout.
+          <div className="space-y-6">
+            <div className="text-sm">Total: {totalItems} items</div>
+            <div className="space-y-1">
+              <div className="">
+                <div className="text-sm">Subtotal:</div>
+                <div className="font-semibold">${subtotal.toFixed(2)}</div>
+              </div>
+              <div className="">
+                <div className="text-xs text-body-subtle">
+                  Taxes, discounts and shipping calculated at checkout.
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+
+      {/* tablet layout */}
+      <div className="hidden md:block lg:hidden border-t border-line-subtle pt-6">
+        <div className="grid grid-cols-[3fr_1fr_1fr] gap-4 items-center">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="outline"
+              className="text-sm"
+              onClick={() => toggleCartDrawer(true)}
+            >
+              View Cart
+            </Button>
+            {<RemoveAllFromCartButton lineIds={existingLineIds} />}
+          </div>
+          <div className="space-y-1 col-span-2">
+            <div className="text-right">
+              <div className="text-sm">Subtotal:</div>
+              <div className="font-semibold">${subtotal.toFixed(2)}</div>
+            </div>
+            <div className="text-right">
+              <div className="text-xs text-body-subtle">
+                Taxes, discounts and shipping calculated at checkout.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* desktop layout */}
+      <div className="hidden lg:block border-t border-line-subtle pt-6">
+        <div className="grid grid-cols-[3fr_1fr_1fr_1fr] gap-4 items-center">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="outline"
+              className="text-sm"
+              onClick={() => toggleCartDrawer(true)}
+            >
+              View Cart
+            </Button>
+            {<RemoveAllFromCartButton lineIds={existingLineIds} />}
+          </div>
+          <div className="text-center text-sm">Total: {totalItems} items</div>
+          <div className="col-span-2">
+            <div className="text-right space-y-1">
+              <div className="text-sm">Subtotal:</div>
+              <div className="font-semibold text-sm">${subtotal.toFixed(2)}</div>
+              <div className="text-xs text-body-subtle">
+                Taxes, discounts and shipping calculated at checkout.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }
 
@@ -87,12 +149,12 @@ function RemoveAllFromCartButton({ lineIds }: { lineIds: string[] }) {
     >
       {(fetcher: FetcherWithComponents<any>) => (
         <Button
-          className="flex items-center gap-1"
+          className="flex items-center gap-1 text-sm"
           variant="underline"
           type="submit"
           disabled={fetcher.state !== "idle"}
         >
-          <TrashIcon /> <span>Remove All</span>
+          <TrashIcon /> <span className="text-sm">Remove All</span>
         </Button>
       )}
     </CartForm>

--- a/app/sections/variant-list/variant-list-items.tsx
+++ b/app/sections/variant-list/variant-list-items.tsx
@@ -9,11 +9,10 @@ import {
   getClientBrowserParameters,
   sendShopifyAnalytics,
 } from "@shopify/hydrogen";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import type { FetcherWithComponents } from "react-router";
 import { Await, useMatches, useRouteLoaderData } from "react-router";
 import type {
-  CartApiQueryFragment,
   ProductQuery,
   ProductVariantFragment,
 } from "storefront-api.generated";
@@ -21,8 +20,8 @@ import { Button } from "~/components/button";
 import { toggleCartDrawer } from "~/components/layout/cart-drawer";
 import type { RootLoader } from "~/root";
 import { DEFAULT_LOCALE } from "~/utils/const";
-import { VariantRow } from "./variant-row";
 import { Subtotal } from "./subtotal";
+import { VariantRow } from "./variant-row";
 
 type Product = NonNullable<ProductQuery["product"]>;
 
@@ -35,33 +34,115 @@ interface VariantQuantity {
   [variantId: string]: number;
 }
 
-export function VariantListItems({ variants }: VariantListItemsProps) {
+export function VariantListItems({ variants, product }: VariantListItemsProps) {
   const rootData = useRouteLoaderData<RootLoader>("root");
+  const sellingPlanGroups = product.sellingPlanGroups || { nodes: [] };
 
   return (
-    <div className="space-y-6">
-      <div className="space-y-4">
-        <div className="grid grid-cols-[3fr_1fr_1fr_1fr] gap-4 border-b border-line-subtle pb-3">
-          <div className="text-sm font-bold uppercase">Variant</div>
-          <div className="text-sm font-bold uppercase text-center ">
-            Quantity
+    <Await resolve={rootData.cart}>
+      {(resolvedCart) => (
+        <div>
+          {/* mobile layout */}
+          <div className="space-y-6 md:hidden">
+            <div className="border-b border-line-subtle py-3">
+              <p className="font-semibold text-sm">PRODUCTS</p>
+            </div>
+            <div className="space-y-6">
+              {variants.map((variant) => (
+                <VariantRow
+                  key={variant.id}
+                  variant={variant}
+                  cart={resolvedCart}
+                  sellingPlanGroups={sellingPlanGroups}
+                />
+              ))}
+            </div>
           </div>
-          <div className="text-sm font-bold uppercase text-center">Price</div>
-          <div className="text-sm font-bold uppercase text-right ">
-            Variant Price
-          </div>
-        </div>
-        <div className="space-y-6">
-          {variants.map((variant) => (
-            <VariantRow key={variant.id} variant={variant} />
-          ))}
-        </div>
-      </div>
 
-      <Await resolve={rootData.cart}>
-        {(resolvedCart) => <Subtotal cart={resolvedCart} variants={variants} />}
-      </Await>
-    </div>
+          <div className="md:hidden">
+            <Subtotal cart={resolvedCart} variants={variants} />
+          </div>
+
+          {/* tablet layout */}
+          <div className="hidden md:block lg:hidden space-y-6">
+            <div className="space-y-4">
+              <div className="grid grid-cols-[3fr_2fr_1fr_1fr] gap-6 border-b border-line-subtle py-3">
+                <div className="text-sm font-bold uppercase">Variant</div>
+                <div className="text-sm font-bold uppercase">
+                  Purchase Method
+                </div>
+                <div className="text-sm font-bold uppercase text-center">
+                  Price
+                </div>
+                <div className="text-sm font-bold uppercase text-right ">
+                  Variant Price
+                </div>
+              </div>
+              <div className="space-y-6">
+                {variants.map((variant) => (
+                  <VariantRow
+                    key={variant.id}
+                    variant={variant}
+                    cart={resolvedCart}
+                    sellingPlanGroups={sellingPlanGroups}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <Subtotal cart={resolvedCart} variants={variants} />
+          </div>
+
+          {/* desktop layout */}
+          <div className="hidden lg:block space-y-6">
+            <div className="space-y-6">
+              {sellingPlanGroups?.nodes?.length > 0 ? (
+                <div className="grid grid-cols-[1fr_280px_270px_160px_153px] gap-6 border-b border-line-subtle py-3">
+                  <div className="text-sm font-semibold uppercase">Variant</div>
+                  <div className="text-sm font-semibold uppercase text-center">
+                    Purchase Method
+                  </div>
+                  <div className="text-sm font-semibold uppercase text-center">
+                    Quantity
+                  </div>
+                  <div className="text-sm font-semibold uppercase text-center">
+                    Price
+                  </div>
+                  <div className="text-sm font-semibold uppercase text-right ">
+                    Variant Price
+                  </div>
+                </div>
+              ) : (
+                <div className="grid grid-cols-[1fr_270px_160px_153px] gap-6 border-b border-line-subtle py-3">
+                  <div className="text-sm font-semibold uppercase">Variant</div>
+                  <div className="text-sm font-semibold uppercase text-center">
+                    Quantity
+                  </div>
+                  <div className="text-sm font-semibold uppercase text-center">
+                    Price
+                  </div>
+                  <div className="text-sm font-semibold uppercase text-right ">
+                    Variant Price
+                  </div>
+                </div>
+              )}
+              <div className="space-y-6">
+                {variants.map((variant) => (
+                  <VariantRow
+                    key={variant.id}
+                    variant={variant}
+                    cart={resolvedCart}
+                    sellingPlanGroups={sellingPlanGroups}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <Subtotal cart={resolvedCart} variants={variants} />
+          </div>
+        </div>
+      )}
+    </Await>
   );
 }
 

--- a/app/sections/variant-list/variant-row.tsx
+++ b/app/sections/variant-list/variant-row.tsx
@@ -2,27 +2,55 @@ import { InfoIcon, TrashIcon } from "@phosphor-icons/react";
 import {
   CartForm,
   Money,
+  type OptimisticCart,
   OptimisticInput,
   useOptimisticCart,
   useOptimisticData,
-  type OptimisticCart,
 } from "@shopify/hydrogen";
-import { Await, useRouteLoaderData } from "react-router";
+import { useState } from "react";
 import type {
   CartApiQueryFragment,
   ProductVariantFragment,
+  SellingPlanGroupFragment,
 } from "storefront-api.generated";
+import { Minus, Plus } from "~/components/icons";
 import { Image } from "~/components/image";
+import { AddToCartAnalytics } from "~/components/product/add-to-cart-button";
+import { PurchaseMethodDropdown } from "~/components/product/purchase-method-dropdown";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
-import type { RootLoader } from "~/root";
 import { cn } from "~/utils/cn";
+import {
+  calculateSellingPlanPrice,
+  getSellingPlanById,
+} from "~/utils/selling-plan-utils";
 
 interface VariantRowProps {
   variant: ProductVariantFragment;
+  cart: OptimisticCart<CartApiQueryFragment>;
+  sellingPlanGroups: { nodes: SellingPlanGroupFragment[] };
 }
 
-export function VariantRow({ variant }: VariantRowProps) {
-  const rootData = useRouteLoaderData<RootLoader>("root");
+export function VariantRow({
+  variant,
+  cart: resolvedCart,
+  sellingPlanGroups,
+}: VariantRowProps) {
+  const initialCartLine = resolvedCart?.lines?.nodes?.find(
+    (line) => line.merchandise.id === variant.id,
+  );
+
+  const initialPlanId =
+    initialCartLine?.sellingPlanAllocation?.sellingPlan?.id || null;
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(
+    initialPlanId,
+  );
+
+  const activeCartLine = resolvedCart?.lines?.nodes?.find((line) => {
+    const isVariantMatch = line.merchandise.id === variant.id;
+    const linePlanId = line.sellingPlanAllocation?.sellingPlan?.id || null;
+    const isPlanMatch = linePlanId === selectedPlanId;
+    return isVariantMatch && isPlanMatch;
+  });
 
   const variantTitle = variant.title === "Default Title" ? "" : variant.title;
 
@@ -33,81 +61,228 @@ export function VariantRow({ variant }: VariantRowProps) {
     variant.quantityAvailable <= 10;
   const isOutOfStock = !variant.availableForSale;
 
+  let basePrice = activeCartLine
+    ? activeCartLine.cost?.amountPerQuantity
+    : variant.price;
+  let unitPrice = basePrice;
+
+  if (selectedPlanId && variant.price) {
+    const selectedPlan = getSellingPlanById(sellingPlanGroups, selectedPlanId);
+    if (selectedPlan) {
+      unitPrice = calculateSellingPlanPrice(variant.price, selectedPlan) as any;
+    }
+  }
+
+  const totalPrice = activeCartLine?.cost?.totalAmount || {
+    amount: "0",
+    currencyCode: variant.price?.currencyCode as any,
+  };
+
   return (
-    <div
-      className={cn(
-        "grid grid-cols-[3fr_1fr_1fr_1fr] gap-4 items-center",
-        isOutOfStock && "opacity-50",
-      )}
-    >
-      <div className="flex items-center gap-3">
-        {variant.image && (
-          <Image
-            data={variant.image}
-            width={64}
-            height={64}
-            className="h-16 w-16 object-cover rounded"
-            alt={variant.image.altText || variantTitle}
-          />
-        )}
-        <div className="space-y-1">
-          <div className="font-medium">{variantTitle}</div>
-          <div className="text-sm text-body/70">SKU: {variant.sku}</div>
-          {isOutOfStock ? (
-            <div className="text-sm text-red-600 font-medium">Out of Stock</div>
-          ) : isLowStock ? (
-            <div className="flex items-center gap-1 text-sm text-orange-600">
-              <InfoIcon size={14} />
-              <span>Low in Stock</span>
-            </div>
-          ) : (
-            <div className="text-sm text-green-600 flex gap-1 items-center">
-              <span className="bg-green-600 size-2 rounded-full" />
-              <span>In Stock</span>
-            </div>
+    <>
+      {/* mobile layout */}
+      <div className="space-y-6 md:hidden">
+        <div className="flex gap-[14px]">
+          {variant.image && (
+            <Image
+              data={variant.image}
+              width={99}
+              height={99}
+              className="h-[99px] w-[99px] object-cover rounded border border-(--color-line-subtle)"
+              alt={variant.image.altText || variantTitle}
+            />
           )}
+          <div className="flex flex-col justify-between">
+            <div className="font-semibold text-sm">{variantTitle}</div>
+            <div className="text-sm text-body/70">SKU: {variant.sku}</div>
+            {isOutOfStock ? (
+              <div className="text-sm text-red-600 font-medium">
+                Out of Stock
+              </div>
+            ) : isLowStock ? (
+              <div className="flex items-center gap-1 text-sm text-orange-600">
+                <InfoIcon size={14} />
+                <span>Low in Stock</span>
+              </div>
+            ) : (
+              <div className="text-sm text-green-600 flex gap-1 items-center">
+                <span className="bg-green-600 size-2 rounded-full" />
+                <span>In Stock</span>
+              </div>
+            )}
+            <div className="text-sm">
+              <Money data={unitPrice} as="span" withoutTrailingZeros />
+              <span>/unit</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <QuantityUpdateButtons
+            cart={resolvedCart}
+            variant={variant}
+            selectedPlanId={selectedPlanId}
+          />
+          <div className="font-semibold text-sm">
+            <Money data={totalPrice} as="span" withoutTrailingZeros />
+          </div>
+        </div>
+
+        {sellingPlanGroups.nodes.length > 0 && (
+          <div className="mt-3">
+            <PurchaseMethodDropdown
+              sellingPlanGroups={sellingPlanGroups}
+              selectedPlanId={selectedPlanId}
+              onPlanChange={setSelectedPlanId}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* tablet layout */}
+      <div
+        className={cn(
+          "hidden md:grid lg:hidden grid-cols-[3fr_2fr_1fr_1fr] gap-6 items-center",
+          isOutOfStock && "opacity-50",
+        )}
+      >
+        <div className="flex items-start gap-3">
+          {variant.image && (
+            <Image
+              data={variant.image}
+              width={99}
+              height={99}
+              className="h-[99px] w-[99px] object-cover rounded border border-(--color-line-subtle)"
+              alt={variant.image.altText || variantTitle}
+            />
+          )}
+          <div className="flex-1 flex flex-col gap-[23px]">
+            <div className="space-y-1">
+              <div className="font-medium">{variantTitle}</div>
+              <div className="text-sm text-body/70">SKU: {variant.sku}</div>
+              {isOutOfStock ? (
+                <div className="text-sm text-red-600 font-medium">
+                  Out of Stock
+                </div>
+              ) : isLowStock ? (
+                <div className="flex items-center gap-1 text-sm text-orange-600">
+                  <InfoIcon size={14} />
+                  <span>Low in Stock</span>
+                </div>
+              ) : (
+                <div className="text-sm text-green-600 flex gap-1 items-center">
+                  <span className="bg-green-600 size-2 rounded-full" />
+                  <span>In Stock</span>
+                </div>
+              )}
+            </div>
+            <QuantityUpdateButtons
+              cart={resolvedCart}
+              variant={variant}
+              selectedPlanId={selectedPlanId}
+            />
+          </div>
+        </div>
+
+        {sellingPlanGroups.nodes.length > 0 ? (
+          <PurchaseMethodDropdown
+            sellingPlanGroups={sellingPlanGroups}
+            selectedPlanId={selectedPlanId}
+            onPlanChange={setSelectedPlanId}
+          />
+        ) : (
+          <div />
+        )}
+
+        <div className="text-center text-sm">
+          <Money data={unitPrice} as="span" withoutTrailingZeros />
+          <span>/unit</span>
+        </div>
+        <div className="text-right font-semibold text-sm">
+          <Money data={totalPrice} as="span" withoutTrailingZeros />
         </div>
       </div>
 
-      <Await resolve={rootData.cart}>
-        {(resolvedCart) => {
-          const cartLine = resolvedCart?.lines?.nodes?.find(
-            (line) => line.merchandise.id === variant.id,
-          );
-          let unitPrice = cartLine
-            ? cartLine.cost?.amountPerQuantity
-            : variant.price;
-          const totalPrice = cartLine?.cost?.totalAmount || {
-            amount: "0",
-            currencyCode: variant.price?.currencyCode,
-          };
+      {/* desktop layout */}
+      <div
+        className={cn(
+          "hidden lg:grid gap-6 items-center",
+          sellingPlanGroups.nodes.length > 0
+            ? "grid-cols-[1fr_280px_270px_160px_153px]"
+            : "grid-cols-[1fr_270px_160px_153px]",
+          isOutOfStock && "opacity-50",
+        )}
+      >
+        <div className="flex items-center gap-3.5">
+          {variant.image && (
+            <Image
+              data={variant.image}
+              width={99}
+              height={99}
+              className="h-[99px] w-[99px] object-cover rounded border border-(--color-line-subtle)"
+              alt={variant.image.altText || variantTitle}
+            />
+          )}
+          <div className="space-y-1">
+            <div className="font-semibold text-sm">{variantTitle}</div>
+            <div className="text-sm text-body/70">SKU: {variant.sku}</div>
+            {isOutOfStock ? (
+              <div className="text-xs text-red-600 font-medium">
+                Out of Stock
+              </div>
+            ) : isLowStock ? (
+              <div className="flex items-center gap-1 text-xs text-orange-600">
+                <InfoIcon size={14} />
+                <span>Low in Stock</span>
+              </div>
+            ) : (
+              <div className="text-xs text-green-600 flex gap-1 items-center">
+                <span className="bg-green-600 size-2 rounded-full" />
+                <span>In Stock</span>
+              </div>
+            )}
+          </div>
+        </div>
 
-          return (
-            <>
-              <QuantityUpdateButtons cart={resolvedCart} variant={variant} />
-              <div className="font-medium text-center">
-                <Money data={unitPrice} as="span" withoutTrailingZeros />
-                <span>/unit</span>
-              </div>
-              <div className="text-right font-semibold">
-                <Money data={totalPrice} as="span" withoutTrailingZeros />
-              </div>
-            </>
-          );
-        }}
-      </Await>
-    </div>
+        {sellingPlanGroups.nodes.length > 0 && (
+          <div className="flex justify-center">
+            <PurchaseMethodDropdown
+              sellingPlanGroups={sellingPlanGroups}
+              selectedPlanId={selectedPlanId}
+              onPlanChange={setSelectedPlanId}
+            />
+          </div>
+        )}
+
+        <div className="flex justify-center">
+          <QuantityUpdateButtons
+            cart={resolvedCart}
+            variant={variant}
+            selectedPlanId={selectedPlanId}
+          />
+        </div>
+        <div className="text-center text-sm">
+          <Money data={unitPrice} as="span" withoutTrailingZeros />
+          <span>/unit</span>
+        </div>
+        <div className="text-right font-semibold text-sm">
+          <Money data={totalPrice} as="span" withoutTrailingZeros />
+        </div>
+      </div>
+    </>
   );
 }
 
 interface QuantityUpdateButtonsProps {
   variant: ProductVariantFragment;
   cart: OptimisticCart<CartApiQueryFragment>;
+  selectedPlanId: string | null;
 }
 
 function QuantityUpdateButtons({
   variant,
   cart: originalCart,
+  selectedPlanId,
 }: QuantityUpdateButtonsProps) {
   type OptimisticData = {
     action?: string;
@@ -118,134 +293,161 @@ function QuantityUpdateButtons({
 
   const increment = variant.quantityRule.increment || 1;
 
-  const existingLine = cart?.lines?.nodes?.find(
-    (line) => line.merchandise.id === variant.id,
-  );
+  const activeLine = cart?.lines?.nodes?.find((line) => {
+    const isVariantMatch = line.merchandise.id === variant.id;
+    const linePlanId = line.sellingPlanAllocation?.sellingPlan?.id || null;
+    const isPlanMatch = linePlanId === selectedPlanId;
+    return isVariantMatch && isPlanMatch;
+  });
 
-  const optimisticId = existingLine?.id;
+  const optimisticId = activeLine?.id;
   const optimisticData = useOptimisticData<OptimisticData>(optimisticId);
 
-  const currentQuantity =
-    optimisticData?.quantity || existingLine?.quantity || 0;
+  const currentQuantity = optimisticData?.quantity || activeLine?.quantity || 0;
 
   const prevQuantity = Number(Math.max(0, currentQuantity - increment));
   const nextQuantity = Number(currentQuantity + increment);
   const isOutOfStock = !variant.availableForSale;
 
-  const showTrashButton = Boolean(existingLine);
+  const showTrashButton = Boolean(activeLine);
+
+  const shouldUpdateActiveLine = Boolean(activeLine);
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-4">
       <VolumePricingInfo variant={variant} />
-      <div className="flex items-center border border-border divide-x divide-border rounded-(--btn-border-radius)">
+      <div className="flex items-center border-2 border-(--color-line) divide-x divide-(--color-line) rounded-(--btn-border-radius)">
         <CartForm
           route="/cart"
           fetcherKey="variant-list"
           action={CartForm.ACTIONS.LinesUpdate}
           inputs={{
-            lines: [{ id: existingLine?.id, quantity: prevQuantity }],
+            lines: [{ id: activeLine?.id, quantity: prevQuantity }],
           }}
         >
           <button
             type="submit"
             name="decrease-quantity"
             aria-label="Decrease quantity"
-            className="h-9 w-9 transition disabled:cursor-not-allowed disabled:text-body-subtle"
+            className="h-11 w-11 flex items-center justify-center transition disabled:cursor-not-allowed disabled:text-body-subtle"
             value={prevQuantity}
             disabled={
-              currentQuantity <= 0 ||
-              existingLine?.isOptimistic ||
-              !existingLine
+              currentQuantity <= 0 || activeLine?.isOptimistic || !activeLine
             }
           >
-            <span>&#8722;</span>
+            <Minus />
             <OptimisticInput
-              id={existingLine?.id}
+              id={activeLine?.id}
               data={{ quantity: prevQuantity }}
             />
           </button>
         </CartForm>
 
         <div
-          className="px-2 w-16 h-9 flex items-center justify-center"
+          className="px-2 w-[68px] h-11 flex items-center justify-center text-sm"
           data-test="item-quantity"
         >
           {currentQuantity}
         </div>
 
-        {existingLine ? (
+        {shouldUpdateActiveLine ? (
           <CartForm
             route="/cart"
             fetcherKey="variant-list"
             action={CartForm.ACTIONS.LinesUpdate}
             inputs={{
-              lines: [{ id: existingLine.id, quantity: nextQuantity }],
+              lines: [{ id: activeLine?.id, quantity: nextQuantity }],
             }}
           >
             <button
               type="submit"
-              className="h-9 w-9 transition disabled:cursor-not-allowed disabled:text-body-subtle"
+              className="h-11 w-11 flex items-center justify-center transition disabled:cursor-not-allowed disabled:text-body-subtle"
               name="increase-quantity"
               value={nextQuantity}
               aria-label="Increase quantity"
-              disabled={existingLine.isOptimistic}
+              disabled={activeLine?.isOptimistic}
             >
-              <span>&#43;</span>
+              <Plus />
               <OptimisticInput
-                id={existingLine.id}
+                id={activeLine?.id}
                 data={{ quantity: nextQuantity }}
               />
             </button>
           </CartForm>
         ) : (
-          <CartForm
-            route="/cart"
-            fetcherKey="variant-list"
-            action={CartForm.ACTIONS.LinesAdd}
-            inputs={{
-              lines: [
-                {
-                  merchandiseId: variant.id,
-                  quantity: increment,
-                  selectedVariant: variant,
-                },
-              ],
-            }}
-          >
-            <button
-              type="submit"
-              className="h-9 w-9 transition disabled:cursor-not-allowed disabled:text-body-subtle"
-              disabled={isOutOfStock}
-            >
-              <span>&#43;</span>
-            </button>
-          </CartForm>
+          <AddToCartWithSellingPlan
+            variant={variant}
+            increment={increment}
+            isOutOfStock={isOutOfStock}
+            selectedPlanId={selectedPlanId}
+          />
         )}
       </div>
-      <div className="w-8">
-        {showTrashButton && (
-          <CartForm
-            route="/cart"
-            fetcherKey="variant-list"
-            action={CartForm.ACTIONS.LinesRemove}
-            inputs={{ lineIds: [existingLine.id] }}
+      {showTrashButton ? (
+        <CartForm
+          route="/cart"
+          fetcherKey="variant-list"
+          action={CartForm.ACTIONS.LinesRemove}
+          inputs={{ lineIds: [activeLine?.id] }}
+        >
+          <button
+            type="submit"
+            aria-label="Remove from cart"
+            className="flex h-4 w-4 items-center justify-center border-none hover:text-red-600 transition"
           >
-            <button
-              type="submit"
-              aria-label="Remove from cart"
-              className="flex h-8 w-8 items-center justify-center border-none hover:text-red-600 transition"
-            >
-              <span className="sr-only">Remove</span>
-              <TrashIcon aria-hidden="true" className="h-4 w-4" />
-              <OptimisticInput
-                id={existingLine.id}
-                data={{ action: "remove" }}
-              />
-            </button>
-          </CartForm>
-        )}
-      </div>
+            <span className="sr-only">Remove</span>
+            <TrashIcon aria-hidden="true" className="h-4 w-4" />
+            <OptimisticInput id={activeLine?.id} data={{ action: "remove" }} />
+          </button>
+        </CartForm>
+      ) : (
+        <div className="w-4" />
+      )}
     </div>
+  );
+}
+
+interface AddToCartWithSellingPlanProps {
+  variant: ProductVariantFragment;
+  increment: number;
+  isOutOfStock: boolean;
+  selectedPlanId: string | null;
+}
+
+function AddToCartWithSellingPlan({
+  variant,
+  increment,
+  isOutOfStock,
+  selectedPlanId,
+}: AddToCartWithSellingPlanProps) {
+  return (
+    <CartForm
+      route="/cart"
+      fetcherKey="variant-list"
+      action={CartForm.ACTIONS.LinesAdd}
+      inputs={{
+        lines: [
+          {
+            merchandiseId: variant.id,
+            quantity: increment,
+            selectedVariant: variant,
+            sellingPlanId: selectedPlanId || undefined,
+          },
+        ],
+      }}
+    >
+      {(fetcher: any) => (
+        <AddToCartAnalytics fetcher={fetcher}>
+          <button
+            type="submit"
+            className="h-11 w-11 flex items-center justify-center transition disabled:cursor-not-allowed disabled:text-body-subtle"
+            disabled={isOutOfStock}
+          >
+            <Plus />
+          </button>
+        </AddToCartAnalytics>
+      )}
+    </CartForm>
   );
 }
 
@@ -262,7 +464,7 @@ function VolumePricingInfo({ variant }: { variant: ProductVariantFragment }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <InfoIcon className="cursor-pointer hover:scale-125 duration-300" />
+        <InfoIcon className="cursor-pointer hover:scale-125 duration-300 text-body-subtle" />
       </TooltipTrigger>
       <TooltipContent
         className="bg-white text-body shadow-lg rounded-lg p-0"

--- a/app/utils/selling-plan-utils.ts
+++ b/app/utils/selling-plan-utils.ts
@@ -1,0 +1,128 @@
+import type { SellingPlanGroupFragment } from "storefront-api.generated";
+
+type SellingPlan = SellingPlanGroupFragment["sellingPlans"]["nodes"][number];
+
+/**
+ * Format selling plan name for display
+ * @example "Deliver every month" → "Deliver every month"
+ * @example "Subscribe & Save" → "Subscribe & Save"
+ */
+export function formatSellingPlanName(plan: SellingPlan): string {
+  return plan.name || "Subscription";
+}
+
+/**
+ * Extract discount text from selling plan
+ * Returns formatted discount string or null if no discount
+ * @example "Save 10%" or "Save $5.00"
+ */
+export function getDiscountText(plan: SellingPlan): string | null {
+  const priceAdjustment = plan.priceAdjustments?.[0];
+  if (!priceAdjustment) {
+    return null;
+  }
+
+  const adjustmentValue = priceAdjustment.adjustmentValue;
+  if (!adjustmentValue) {
+    return null;
+  }
+
+  if ("adjustmentPercentage" in adjustmentValue) {
+    return `Save ${adjustmentValue.adjustmentPercentage}%`;
+  }
+
+  if (
+    "adjustmentAmount" in adjustmentValue &&
+    adjustmentValue.adjustmentAmount
+  ) {
+    const amount = adjustmentValue.adjustmentAmount.amount;
+    const currencyCode = adjustmentValue.adjustmentAmount.currencyCode;
+    return `Save ${currencyCode} ${amount}`;
+  }
+
+  return null;
+}
+
+/**
+ * Get all available selling plans for the product
+ * Filters out empty groups and returns flattened list
+ */
+export function getAvailableSellingPlans(sellingPlanGroups: {
+  nodes: SellingPlanGroupFragment[];
+}): SellingPlan[] {
+  if (!sellingPlanGroups?.nodes?.length) {
+    return [];
+  }
+
+  const plans: SellingPlan[] = [];
+
+  for (const group of sellingPlanGroups.nodes) {
+    if (group.sellingPlans?.nodes?.length) {
+      plans.push(...group.sellingPlans.nodes);
+    }
+  }
+
+  return plans;
+}
+
+/**
+ * Get selling plan by ID from groups
+ */
+export function getSellingPlanById(
+  sellingPlanGroups: { nodes: SellingPlanGroupFragment[] },
+  planId: string,
+): SellingPlan | null {
+  const allPlans = getAvailableSellingPlans(sellingPlanGroups);
+  return allPlans.find((plan) => plan.id === planId) || null;
+}
+
+/**
+ * Calculate the adjusted price when a selling plan is applied
+ * Handles: Fixed price, Fixed amount off, Percentage off
+ */
+export function calculateSellingPlanPrice(
+  originalPrice: { amount: string; currencyCode: string },
+  plan: SellingPlan,
+): { amount: string; currencyCode: string } {
+  const priceAdjustment = plan?.priceAdjustments?.[0];
+  const adjustmentValue = priceAdjustment?.adjustmentValue;
+
+  if (!adjustmentValue) {
+    return originalPrice;
+  }
+
+  // Fixed price
+  if ("price" in adjustmentValue && adjustmentValue.price) {
+    return adjustmentValue.price;
+  }
+
+  // Fixed amount off
+  if (
+    "adjustmentAmount" in adjustmentValue &&
+    adjustmentValue.adjustmentAmount
+  ) {
+    return {
+      amount: String(
+        Number(originalPrice.amount) -
+          Number(adjustmentValue.adjustmentAmount.amount),
+      ),
+      currencyCode: originalPrice.currencyCode,
+    };
+  }
+
+  // Percentage off
+  if (
+    "adjustmentPercentage" in adjustmentValue &&
+    adjustmentValue.adjustmentPercentage
+  ) {
+    return {
+      amount: String(
+        Number(originalPrice.amount) *
+          (1 - adjustmentValue.adjustmentPercentage / 100),
+      ),
+      currencyCode: originalPrice.currencyCode,
+    };
+  }
+
+  return originalPrice;
+}

--- a/app/weaverse/components.ts
+++ b/app/weaverse/components.ts
@@ -66,6 +66,7 @@ import * as ProductSummary from "~/sections/main-product/product-summary";
 import * as ProductTitle from "~/sections/main-product/product-title";
 import * as ProductVariantSelector from "~/sections/main-product/product-variant-selector";
 import * as ProductVendor from "~/sections/main-product/product-vendor";
+import * as ProductSubscriptionSelector from "~/sections/main-product/product-subscription-selector";
 import * as MapSection from "~/sections/map";
 import * as Multicolumn from "~/sections/multicolumn";
 import * as MulticolumnItem from "~/sections/multicolumn/item";
@@ -153,6 +154,7 @@ export const components: HydrogenComponent[] = [
   ProductVariantSelector,
   ProductQuantitySelector,
   ProductATCButtons,
+  ProductSubscriptionSelector,
   ProductCollapsibleDetails,
   RelatedProducts,
   RelatedProductsHeader,

--- a/server.ts
+++ b/server.ts
@@ -210,6 +210,7 @@ const CART_QUERY_FRAGMENT = `#graphql
     }
     sellingPlanAllocation {
       sellingPlan {
+        id
         name
       }
     }
@@ -267,6 +268,12 @@ const CART_QUERY_FRAGMENT = `#graphql
       }
       compareAtAmountPerQuantity {
         ...Money
+      }
+    }
+    sellingPlanAllocation {
+      sellingPlan {
+        id
+        name
       }
     }
     merchandise {


### PR DESCRIPTION
Add full subscription support following Shopify Subscriptions API:
- Subscription plan selector on PDP with price adjustments
- Context-aware cart handling for subscription vs one-time purchases
- /account/subscriptions page for subscription management
- Analytics tracking for subscription events
- Enhanced GraphQL queries for selling plan data

Reference: https://shopify.dev/docs/storefronts/headless/hydrogen/cookbook/subscriptions